### PR TITLE
Update hooks.php

### DIFF
--- a/user_cas/lib/hooks.php
+++ b/user_cas/lib/hooks.php
@@ -31,6 +31,7 @@ class OC_USER_CAS_Hooks {
 
 		if (phpCAS::isAuthenticated()) {
 			$attributes = phpCAS::getAttributes();
+			$attributes[$casBackend->usernameMapping][0]=phpCAS::getUser();
 
 			if (array_key_exists($casBackend->usernameMapping, $attributes) && $attributes[$casBackend->usernameMapping][0] == $uid) {
 				if (array_key_exists($casBackend->mailMapping, $attributes)) {


### PR DESCRIPTION
adding line to force the uid to be set on attributes, causing the following code to be escaped by further if conditions.
