### PR TITLE
Fix two user_saml problems

### DIFF
--- a/user_saml/appinfo/app.php
+++ b/user_saml/appinfo/app.php
@@ -24,7 +24,7 @@
 
 if (OCP\App::isEnabled('user_saml')) {
 	$ocVersion = implode('.',OCP\Util::getVersion());
-	if (version_compare($ocVersion,'4.93','<')) {
+	if (version_compare($ocVersion,'5.0','<')) {
 		if ( ! function_exists('p')) {
 			function p($string) {
 				print(OC_Util::sanitizeHTML($string));

--- a/user_saml/appinfo/app.php
+++ b/user_saml/appinfo/app.php
@@ -23,6 +23,14 @@
 
 
 if (OCP\App::isEnabled('user_saml')) {
+	$ocVersion = implode('.',OCP\Util::getVersion());
+	if (version_compare($ocVersion,'4.93','<')) {
+		if ( ! function_exists('p')) {
+			function p($string) {
+				print(OC_Util::sanitizeHTML($string));
+			}
+		}
+	}
 
 	require_once 'user_saml/user_saml.php';
 

--- a/user_saml/templates/settings.php
+++ b/user_saml/templates/settings.php
@@ -21,6 +21,7 @@
 		<p><label for="saml_email_mapping"><?php p($l->t('Email'));?></label><input type="text" id="saml_email_mapping" name="saml_email_mapping" value="<?php p($_['saml_email_mapping']); ?>" /></p>
 		<p><label for="saml_group_mapping"><?php p($l->t('Group'));?></label><input type="text" id="saml_group_mapping" name="saml_group_mapping" value="<?php p($_['saml_group_mapping']); ?>" /></p>
 	</fieldset>
+	<input type="hidden" name="requesttoken" value="<?php echo $_['requesttoken'] ?>" id="requesttoken">
 	<input type="submit" value="Save" />
 	</div>
 


### PR DESCRIPTION
The user_saml app isn't fully working on OC 4.5.12. There are two issues that should be fixed by this PR:
- When setting up the module (inside the settings page), all you get is a `Token expired. Please, reload page` message. The request token seems to be missing from the settings page, so this PR adds it.
- The p() function isn't defined on OC 4.5.x, so the module just refuses to work. Now the app initialization method checks the OC version and defines p() if needed
