### PR TITLE
Fix User_Saml force_saml_login saving

### DIFF
--- a/user_saml/settings.php
+++ b/user_saml/settings.php
@@ -34,7 +34,11 @@ if ($_POST) {
 	foreach($params as $param) {
 		if (isset($_POST[$param])) {
 			OCP\Config::setAppValue('user_saml', $param, $_POST[$param]);
-		}  
+		}
+		elseif ('saml_force_saml_login' == $param) {
+			// unchecked checkboxes are not included in the post paramters
+			OCP\Config::setAppValue('user_saml', $param, 0);
+		}
 		elseif ('saml_autocreate' == $param) {
 			// unchecked checkboxes are not included in the post paramters
 			OCP\Config::setAppValue('user_saml', $param, 0);


### PR DESCRIPTION
The save logic missed out the force_saml_login parameter. This change allows this value to be saved correctly.
